### PR TITLE
Fix exception when icon_url is null

### DIFF
--- a/src/main/java/club/minnced/discord/webhook/receive/EntityFactory.java
+++ b/src/main/java/club/minnced/discord/webhook/receive/EntityFactory.java
@@ -121,7 +121,7 @@ public class EntityFactory {
         if (json == null)
             return null;
         final String text = json.getString("text");
-        final String icon = json.getString("icon_url");
+        final String icon = json.optString("icon_url", null);
         return new WebhookEmbed.EmbedFooter(text, icon);
     }
 


### PR DESCRIPTION
Fixes the JSONException occuring when the icon_url is set to null, thus not existing in the JSONObject