### PR TITLE
Refactored WebhookMessageBuilder#setContent into two new methods

### DIFF
--- a/src/main/java/club/minnced/discord/webhook/send/WebhookMessageBuilder.java
+++ b/src/main/java/club/minnced/discord/webhook/send/WebhookMessageBuilder.java
@@ -143,12 +143,12 @@ public class WebhookMessageBuilder {
         }
         return this;
     }
-
+    
     /**
      * Configures the content for this builder
      *
      * @param content
-     *         The (nullable) content to use
+     *         The content to set
      *
      * @return This builder for chaining convenience
      *
@@ -160,9 +160,30 @@ public class WebhookMessageBuilder {
         if (content != null && content.length() > 2000)
             throw new IllegalArgumentException("Content may not exceed 2000 characters!");
         if (content != null)
-            this.content.replace(0, content.length(), content);
+            this.content.setLength(0);
+            this.content.append(content);
         else
             this.content.setLength(0);
+        return this;
+    }
+
+    /**
+     * Append content to the beginning of the current content for this builder
+     *
+     * @param content
+     *         The content to append to the beginning
+     *
+     * @return This builder for chaining convenience
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the content is larger than 2000 characters
+     */
+    @NotNull
+    public WebhookMessageBuilder appendToBeginningOfContent(@NotNull String content) {
+        if (content.length() > 2000)
+            throw new IllegalArgumentException("Content may not exceed 2000 characters!");
+        else
+            this.content.replace(0, content.length(), content);
         return this;
     }
 

--- a/src/main/java/club/minnced/discord/webhook/send/WebhookMessageBuilder.java
+++ b/src/main/java/club/minnced/discord/webhook/send/WebhookMessageBuilder.java
@@ -180,6 +180,7 @@ public class WebhookMessageBuilder {
      */
     @NotNull
     public WebhookMessageBuilder appendToBeginningOfContent(@NotNull String content) {
+        Objects.requireNonNull(content, "Content");
         if (content.length() > 2000)
             throw new IllegalArgumentException("Content may not exceed 2000 characters!");
         else


### PR DESCRIPTION
#setContent's name and actual function were extremely different, so I've refactored them into two different methods. The intended function, and the current function. Previously, the content was just being added onto the beginning of the current content, even though the method was called "set", not "appendToBeginning". I've fixed this issue by setting the length to 0, then appending, and moved the old code into a new function.