### PR TITLE
Add a better way to handle http exceptions

### DIFF
--- a/src/main/java/club/minnced/discord/webhook/WebhookClient.java
+++ b/src/main/java/club/minnced/discord/webhook/WebhookClient.java
@@ -342,7 +342,7 @@ public class WebhookClient implements AutoCloseable {
         final InputStream stream = IOUtil.getBody(response);
         final String responseBody = stream == null ? "" : new String(IOUtil.readAllBytes(stream));
 
-        return new HttpException("Request returned failure " + response.code() + ": " + responseBody);
+        return new HttpException(response.code(), responseBody);
     }
 
     @NotNull

--- a/src/main/java/club/minnced/discord/webhook/exception/HttpException.java
+++ b/src/main/java/club/minnced/discord/webhook/exception/HttpException.java
@@ -16,23 +16,40 @@
 
 package club.minnced.discord.webhook.exception;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+
+/**
+ * Exception thrown in case of unexpected non-2xx HTTP response.
+ */
 public class HttpException extends RuntimeException {
+
     private final int code;
     private final String body;
 
-    public HttpException(int code, @NotNull String body) {
+    public HttpException(int code, @Nullable String body) {
         super("Request returned failure " + code + ": " + body);
         this.body = body;
         this.code = code;
     }
 
+    /**
+     * The code of HTTP response
+     *
+     * @return The code
+     */
     public int getCode() {
         return code;
     }
 
+    /**
+     * The body of HTTP response
+     *
+     * @return The body
+     */
+    @Nullable
     public String getBody() {
         return body;
     }
+
 }

--- a/src/main/java/club/minnced/discord/webhook/exception/HttpException.java
+++ b/src/main/java/club/minnced/discord/webhook/exception/HttpException.java
@@ -19,7 +19,20 @@ package club.minnced.discord.webhook.exception;
 import org.jetbrains.annotations.NotNull;
 
 public class HttpException extends RuntimeException {
-    public HttpException(@NotNull String message) {
-        super(message);
+    private final int code;
+    private final String body;
+
+    public HttpException(int code, @NotNull String body) {
+        super("Request returned failure " + code + ": " + body);
+        this.body = body;
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getBody() {
+        return body;
     }
 }


### PR DESCRIPTION
If something goes wrong while sending a message to the webhook, e.g. the token is incorrect. WebhookClient throws an exception with a message from which it is difficult to extract e.g. an error code. Pull request changes it so that error handling is simpler.