### PR TITLE
execute new call not in try resource block

### DIFF
--- a/src/main/java/club/minnced/discord/webhook/WebhookClient.java
+++ b/src/main/java/club/minnced/discord/webhook/WebhookClient.java
@@ -582,7 +582,8 @@ public class WebhookClient implements AutoCloseable {
         }
 
         final okhttp3.Request request = newRequest(req);
-        try (Response response = client.newCall(request).execute()) {
+        try {
+            Response response = client.newCall(request).execute();
             bucket.update(response);
             if (response.code() == Bucket.RATE_LIMIT_CODE) {
                 backoffQueue();


### PR DESCRIPTION
When a SocketTimeoutException in the try resource occurs, the form AutoCloseable implemented close() method is called. Shutdown is set to true and the ScheduledExecutorService will be shutted down. It stops sending webhooks