### PR TITLE
Fix JSONException when parsing certain providers in webhook messages

### DIFF
--- a/src/main/java/club/minnced/discord/webhook/receive/EntityFactory.java
+++ b/src/main/java/club/minnced/discord/webhook/receive/EntityFactory.java
@@ -173,8 +173,8 @@ public class EntityFactory {
     public static ReadonlyEmbed.EmbedProvider makeEmbedProvider(@Nullable JSONObject json) {
         if (json == null)
             return null;
-        final String url = json.getString("url");
-        final String name = json.getString("name");
+        final String url = json.optString("url", null);
+        final String name = json.optString("name", null);
         return new ReadonlyEmbed.EmbedProvider(name, url);
     }
 

--- a/src/main/java/club/minnced/discord/webhook/receive/ReadonlyEmbed.java
+++ b/src/main/java/club/minnced/discord/webhook/receive/ReadonlyEmbed.java
@@ -144,27 +144,27 @@ public class ReadonlyEmbed extends WebhookEmbed {
     public static class EmbedProvider implements JSONString {
         private final String name, url;
 
-        public EmbedProvider(@NotNull String name, @NotNull String url) {
+        public EmbedProvider(@Nullable String name, @Nullable String url) {
             this.name = name;
             this.url = url;
         }
 
         /**
-         * The name of the provider
+         * The name of the provider, or {@code null} if none is set
          *
          * @return The name
          */
-        @NotNull
+        @Nullable
         public String getName() {
             return name;
         }
 
         /**
-         * The url of the provider
+         * The url of the provider, or {@code null} if none is set
          *
          * @return The url
          */
-        @NotNull
+        @Nullable
         public String getUrl() {
             return url;
         }


### PR DESCRIPTION
Fixed improper nullability handling of webhook messages' provider url/name. [According to Discord](https://discord.com/developers/docs/resources/channel#embed-object-embed-provider-structure), either may not be present in a webhook message.

Fixes #34