### PR TITLE
Add overloads for string message ids

### DIFF
--- a/src/main/java/club/minnced/discord/webhook/WebhookClient.java
+++ b/src/main/java/club/minnced/discord/webhook/WebhookClient.java
@@ -459,6 +459,97 @@ public class WebhookClient implements AutoCloseable {
     }
 
     /**
+     * Edits the target message and updates it with the provided {@link club.minnced.discord.webhook.send.WebhookMessage}
+     * to the webhook.
+     * <br>The returned future receives {@code null} if {@link club.minnced.discord.webhook.WebhookClientBuilder#setWait(boolean)}
+     * was set to false.
+     *
+     * <p><b>This will override the default {@link AllowedMentions} of this client!</b>
+     *
+     * @param  messageId
+     *         The target message id
+     * @param  message
+     *         The message to send
+     *
+     * @return {@link java.util.concurrent.CompletableFuture}
+     *
+     * @see    #isWait()
+     */
+    @NotNull
+    public CompletableFuture<ReadonlyMessage> edit(@NotNull String messageId, @NotNull WebhookMessage message) {
+        Objects.requireNonNull(message, "WebhookMessage");
+        return execute(message.getBody(), messageId, RequestType.EDIT);
+    }
+
+    /**
+     * Edits the target message and updates it with the provided {@link club.minnced.discord.webhook.send.WebhookEmbed} to the webhook.
+     * <br>The returned future receives {@code null} if {@link club.minnced.discord.webhook.WebhookClientBuilder#setWait(boolean)}
+     * was set to false.
+     *
+     * @param  messageId
+     *         The target message id
+     * @param  first
+     *         The first embed to send
+     * @param  embeds
+     *         Optional additional embeds to send, up to 10
+     *
+     * @return {@link java.util.concurrent.CompletableFuture}
+     *
+     * @see    #isWait()
+     * @see    #edit(long, club.minnced.discord.webhook.send.WebhookMessage)
+     */
+    @NotNull
+    public CompletableFuture<ReadonlyMessage> edit(@NotNull String messageId, @NotNull WebhookEmbed first, @NotNull WebhookEmbed... embeds) {
+        return edit(messageId, WebhookMessage.embeds(first, embeds));
+    }
+
+    /**
+     * Edits the target message and updates it with the provided {@link club.minnced.discord.webhook.send.WebhookEmbed} to the webhook.
+     * <br>The returned future receives {@code null} if {@link club.minnced.discord.webhook.WebhookClientBuilder#setWait(boolean)}
+     * was set to false.
+     *
+     * @param  messageId
+     *         The target message id
+     * @param  embeds
+     *         The embeds to send
+     *
+     * @return {@link java.util.concurrent.CompletableFuture}
+     *
+     * @see    #isWait()
+     * @see    #edit(long, club.minnced.discord.webhook.send.WebhookMessage)
+     */
+    @NotNull
+    public CompletableFuture<ReadonlyMessage> edit(@NotNull String messageId, @NotNull Collection<WebhookEmbed> embeds) {
+        return edit(messageId, WebhookMessage.embeds(embeds));
+    }
+
+    /**
+     * Edits the target message and updates it with the provided content as normal message to the webhook.
+     * <br>The returned future receives {@code null} if {@link club.minnced.discord.webhook.WebhookClientBuilder#setWait(boolean)}
+     * was set to false.
+     *
+     * @param  messageId
+     *         The target message id
+     * @param  content
+     *         The content to send
+     *
+     * @return {@link java.util.concurrent.CompletableFuture}
+     *
+     * @see    #isWait()
+     * @see    #edit(long, club.minnced.discord.webhook.send.WebhookMessage)
+     */
+    @NotNull
+    public CompletableFuture<ReadonlyMessage> edit(@NotNull String messageId, @NotNull String content) {
+        Objects.requireNonNull(content, "Content");
+        content = content.trim();
+        if (content.isEmpty())
+            throw new IllegalArgumentException("Cannot send an empty message");
+        if (content.length() > 2000)
+            throw new IllegalArgumentException("Content may not exceed 2000 characters");
+        return edit(messageId, new WebhookMessageBuilder().setContent(content).build());
+    }
+
+    /**
      * Deletes the message with the provided ID.
      *
      * @param  messageId
@@ -471,6 +562,21 @@ public class WebhookClient implements AutoCloseable {
         return execute(null, Long.toUnsignedString(messageId), RequestType.DELETE).thenApply(v -> null);
     }
 
+    /**
+     * Deletes the message with the provided ID.
+     *
+     * @param  messageId
+     *         The target message id
+     *
+     * @throws NullPointerException
+     *         If null is provided
+     *
+     * @return {@link java.util.concurrent.CompletableFuture}
+     */
+    @NotNull
+    public CompletableFuture<Void> delete(@NotNull String messageId) {
+        return execute(null, messageId, RequestType.DELETE).thenApply(v -> null);
+    }
 
     private JSONObject newJson()
     {
@@ -503,8 +609,10 @@ public class WebhookClient implements AutoCloseable {
     protected CompletableFuture<ReadonlyMessage> execute(RequestBody body, @Nullable String messageId, @NotNull RequestType type) {
         checkShutdown();
         String endpoint = url;
-        if (type != RequestType.SEND)
+        if (type != RequestType.SEND) {
+            Objects.requireNonNull(messageId, "Message ID");
             endpoint += "/messages/" + messageId;
+        }
         if (parseMessage)
             endpoint += "?wait=true";
         return queueRequest(endpoint, type.method, body);

--- a/src/main/java/club/minnced/discord/webhook/WebhookClient.java
+++ b/src/main/java/club/minnced/discord/webhook/WebhookClient.java
@@ -577,6 +577,7 @@ public class WebhookClient implements AutoCloseable {
     public CompletableFuture<Void> delete(@NotNull String messageId) {
         return execute(null, messageId, RequestType.DELETE).thenApply(v -> null);
     }
+
     /**
      * Get the message with the provided ID.
      * <br>Only messages sent by this webhook can be retrieved.
@@ -588,9 +589,25 @@ public class WebhookClient implements AutoCloseable {
      */
     @NotNull
     public CompletableFuture<ReadonlyMessage> get(long messageId) {
-        return execute(null, Long.toUnsignedString(messageId), RequestType.GET);
+        return get(Long.toUnsignedString(messageId));
     }
 
+    /**
+     * Get the message with the provided ID.
+     * <br>Only messages sent by this webhook can be retrieved.
+     *
+     * @param  messageId
+     *         The target message id
+     *
+     * @throws NullPointerException
+     *         If null is provided
+     *
+     * @return {@link java.util.concurrent.CompletableFuture}
+     */
+    @NotNull
+    public CompletableFuture<ReadonlyMessage> get(@NotNull String messageId) {
+        return execute(null, messageId, RequestType.GET);
+    }
 
     private JSONObject newJson()
     {

--- a/src/main/java/club/minnced/discord/webhook/external/D4JWebhookClient.java
+++ b/src/main/java/club/minnced/discord/webhook/external/D4JWebhookClient.java
@@ -79,4 +79,27 @@ public class D4JWebhookClient extends WebhookClient {
         WebhookMessage message = WebhookMessageBuilder.fromD4J(callback).build();
         return Mono.fromFuture(() -> edit(messageId, message));
     }
+
+    /**
+     * Edits the target message with the provided {@link MessageCreateSpec} to the webhook.
+     *
+     * @param  messageId
+     *         The target message id
+     * @param  callback
+     *         The callback used to specify the desired message settings
+     *
+     * @throws NullPointerException
+     *         If null is provided
+     *
+     * @return {@link Mono}
+     *
+     * @see    #isWait()
+     * @see    WebhookMessageBuilder#fromD4J(Consumer)
+     */
+    @NotNull
+    @CheckReturnValue
+    public Mono<ReadonlyMessage> edit(@NotNull String messageId, @NotNull Consumer<? super MessageCreateSpec> callback) {
+        WebhookMessage message = WebhookMessageBuilder.fromD4J(callback).build();
+        return Mono.fromFuture(() -> edit(messageId, message));
+    }
 }

--- a/src/main/java/club/minnced/discord/webhook/external/JDAWebhookClient.java
+++ b/src/main/java/club/minnced/discord/webhook/external/JDAWebhookClient.java
@@ -109,4 +109,46 @@ public class JDAWebhookClient extends WebhookClient {
     public CompletableFuture<ReadonlyMessage> edit(long messageId, @NotNull net.dv8tion.jda.api.entities.MessageEmbed embed) {
         return edit(messageId, WebhookEmbedBuilder.fromJDA(embed).build());
     }
+
+    /**
+     * Edits the target message with the provided {@link net.dv8tion.jda.api.entities.Message Message} to the webhook.
+     *
+     * @param  messageId
+     *         The target message id
+     * @param  message
+     *         The message to send
+     *
+     * @throws NullPointerException
+     *         If null is provided
+     *
+     * @return {@link CompletableFuture}
+     *
+     * @see    #isWait()
+     * @see    WebhookMessageBuilder#fromJDA(Message)
+     */
+    @NotNull
+    public CompletableFuture<ReadonlyMessage> edit(@NotNull String messageId, @NotNull net.dv8tion.jda.api.entities.Message message) {
+        return edit(messageId, WebhookMessageBuilder.fromJDA(message).build());
+    }
+
+    /**
+     * Edits the target message with the provided {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbed} to the webhook.
+     *
+     * @param  messageId
+     *         The target message id
+     * @param  embed
+     *         The embed to send
+     *
+     * @throws NullPointerException
+     *         If null is provided
+     *
+     * @return {@link CompletableFuture}
+     *
+     * @see    #isWait()
+     * @see    WebhookEmbedBuilder#fromJDA(net.dv8tion.jda.api.entities.MessageEmbed)
+     */
+    @NotNull
+    public CompletableFuture<ReadonlyMessage> edit(@NotNull String messageId, @NotNull net.dv8tion.jda.api.entities.MessageEmbed embed) {
+        return edit(messageId, WebhookEmbedBuilder.fromJDA(embed).build());
+    }
 }

--- a/src/main/java/club/minnced/discord/webhook/external/JavacordWebhookClient.java
+++ b/src/main/java/club/minnced/discord/webhook/external/JavacordWebhookClient.java
@@ -112,4 +112,46 @@ public class JavacordWebhookClient extends WebhookClient {
     public CompletableFuture<ReadonlyMessage> edit(long messageId, @NotNull org.javacord.api.entity.message.embed.Embed embed) {
         return edit(messageId, WebhookEmbedBuilder.fromJavacord(embed).build());
     }
+
+    /**
+     * Edits the target message with the provided {@link org.javacord.api.entity.message.Message Message} to the webhook.
+     *
+     * @param  messageId
+     *         The target message id
+     * @param  message
+     *         The message to send
+     *
+     * @throws NullPointerException
+     *         If null is provided
+     *
+     * @return {@link CompletableFuture}
+     *
+     * @see    #isWait()
+     * @see    WebhookMessageBuilder#fromJavacord(org.javacord.api.entity.message.Message)
+     */
+    @NotNull
+    public CompletableFuture<ReadonlyMessage> edit(@NotNull String messageId, @NotNull org.javacord.api.entity.message.Message message) {
+        return edit(messageId, WebhookMessageBuilder.fromJavacord(message).build());
+    }
+
+    /**
+     * Edits the target message with the provided {@link org.javacord.api.entity.message.embed.Embed Embed} to the webhook.
+     *
+     * @param  messageId
+     *         The target message id
+     * @param  embed
+     *         The embed to send
+     *
+     * @throws NullPointerException
+     *         If null is provided
+     *
+     * @return {@link CompletableFuture}
+     *
+     * @see    #isWait()
+     * @see    WebhookEmbedBuilder#fromJavacord(org.javacord.api.entity.message.embed.Embed)
+     */
+    @NotNull
+    public CompletableFuture<ReadonlyMessage> edit(@NotNull String messageId, @NotNull org.javacord.api.entity.message.embed.Embed embed) {
+        return edit(messageId, WebhookEmbedBuilder.fromJavacord(embed).build());
+    }
 }


### PR DESCRIPTION
This should help for webhook interactions which use `"@original"` as the id.