### PR TITLE
Add support for threads

### DIFF
--- a/src/main/java/club/minnced/discord/webhook/WebhookClient.java
+++ b/src/main/java/club/minnced/discord/webhook/WebhookClient.java
@@ -672,11 +672,14 @@ public class WebhookClient implements AutoCloseable {
     }
 
     /**
-     * Stops the executor used by this pool
+     * Stops the thread pool used by this client.
+     * <br>Any further requests to this client or clients with the same thread pool will be rejected.
      */
     @Override
     public void close() {
         isShutdown = true;
+        if (parent != null)
+            parent.close();
         if (queue.isEmpty())
             pool.shutdown();
     }

--- a/src/main/java/club/minnced/discord/webhook/WebhookClient.java
+++ b/src/main/java/club/minnced/discord/webhook/WebhookClient.java
@@ -700,7 +700,8 @@ public class WebhookClient implements AutoCloseable {
             query.add("wait=true");
         if (threadId != 0L)
             query.add("thread_id=" + Long.toUnsignedString(threadId));
-        endpoint += "?" + String.join("&", query);
+        if (!query.isEmpty())
+            endpoint += "?" + String.join("&", query);
         return queueRequest(endpoint, type.method, body);
     }
 

--- a/src/main/java/club/minnced/discord/webhook/WebhookClient.java
+++ b/src/main/java/club/minnced/discord/webhook/WebhookClient.java
@@ -59,11 +59,9 @@ public class WebhookClient implements AutoCloseable {
     public static final String USER_AGENT = "Webhook(https://github.com/MinnDevelopment/discord-webhooks, " + LibraryInfo.VERSION + ")";
     private static final Logger LOG = LoggerFactory.getLogger(WebhookClient.class);
 
-    protected final boolean canShutdown = false;
-    protected final long threadId;
-
     protected final String url;
     protected final long id;
+    protected final long threadId;
     protected final OkHttpClient client;
     protected final ScheduledExecutorService pool;
     protected final Bucket bucket;

--- a/src/main/java/club/minnced/discord/webhook/WebhookClientBuilder.java
+++ b/src/main/java/club/minnced/discord/webhook/WebhookClientBuilder.java
@@ -47,6 +47,7 @@ public class WebhookClientBuilder { //TODO: tests
 
     protected final long id;
     protected final String token;
+    protected long threadId;
     protected ScheduledExecutorService pool;
     protected OkHttpClient client;
     protected ThreadFactory threadFactory;
@@ -253,6 +254,21 @@ public class WebhookClientBuilder { //TODO: tests
     }
 
     /**
+     * The ID for the thread you want the messages to be posted to.
+     * <br>You can use {@link WebhookClient#onThread(long)} to send specific messages to threads.
+     *
+     * @param  threadId
+     *         The target thread id, or 0 to not use threads
+     *
+     * @return The current builder, for chaining convenience
+     */
+    @NotNull
+    public WebhookClientBuilder setThreadId(long threadId) {
+        this.threadId = threadId;
+        return this;
+    }
+
+    /**
      * Builds the {@link club.minnced.discord.webhook.WebhookClient}
      * with the current settings
      *
@@ -262,7 +278,7 @@ public class WebhookClientBuilder { //TODO: tests
     public WebhookClient build() {
         OkHttpClient client = this.client == null ? new OkHttpClient() : this.client;
         ScheduledExecutorService pool = this.pool != null ? this.pool : ThreadPools.getDefaultPool(id, threadFactory, isDaemon);
-        return new WebhookClient(id, token, parseMessage, client, pool, allowedMentions);
+        return new WebhookClient(id, token, parseMessage, client, pool, allowedMentions, threadId);
     }
 
     /**
@@ -275,7 +291,7 @@ public class WebhookClientBuilder { //TODO: tests
     public JDAWebhookClient buildJDA() {
         OkHttpClient client = this.client == null ? new OkHttpClient() : this.client;
         ScheduledExecutorService pool = this.pool != null ? this.pool : ThreadPools.getDefaultPool(id, threadFactory, isDaemon);
-        return new JDAWebhookClient(id, token, parseMessage, client, pool, allowedMentions);
+        return new JDAWebhookClient(id, token, parseMessage, client, pool, allowedMentions, threadId);
     }
 
     /**
@@ -288,7 +304,7 @@ public class WebhookClientBuilder { //TODO: tests
     public D4JWebhookClient buildD4J() {
         OkHttpClient client = this.client == null ? new OkHttpClient() : this.client;
         ScheduledExecutorService pool = this.pool != null ? this.pool : ThreadPools.getDefaultPool(id, threadFactory, isDaemon);
-        return new D4JWebhookClient(id, token, parseMessage, client, pool, allowedMentions);
+        return new D4JWebhookClient(id, token, parseMessage, client, pool, allowedMentions, threadId);
     }
 
     /**
@@ -301,6 +317,6 @@ public class WebhookClientBuilder { //TODO: tests
     public JavacordWebhookClient buildJavacord() {
         OkHttpClient client = this.client == null ? new OkHttpClient() : this.client;
         ScheduledExecutorService pool = this.pool != null ? this.pool : ThreadPools.getDefaultPool(id, threadFactory, isDaemon);
-        return new JavacordWebhookClient(id, token, parseMessage, client, pool, allowedMentions);
+        return new JavacordWebhookClient(id, token, parseMessage, client, pool, allowedMentions, threadId);
     }
 }

--- a/src/main/java/club/minnced/discord/webhook/external/D4JWebhookClient.java
+++ b/src/main/java/club/minnced/discord/webhook/external/D4JWebhookClient.java
@@ -21,11 +21,21 @@ import java.util.regex.Matcher;
 
 public class D4JWebhookClient extends WebhookClient {
     public D4JWebhookClient(long id, String token, boolean parseMessage, OkHttpClient client, ScheduledExecutorService pool, AllowedMentions mentions) {
-        super(id, token, parseMessage, client, pool, mentions);
+        this(id, token, parseMessage, client, pool, mentions, 0L);
+    }
+
+    public D4JWebhookClient(long id, String token, boolean parseMessage, OkHttpClient client, ScheduledExecutorService pool, AllowedMentions mentions, long threadId) {
+        super(id, token, parseMessage, client, pool, mentions, threadId);
+    }
+
+    protected D4JWebhookClient(D4JWebhookClient parent, long threadId) {
+        super(parent, threadId);
     }
 
     /**
      * Creates a D4JWebhookClient for the provided webhook.
+     *
+     * <p>You can use {@link #onThread(long)} to target specific threads on the channel.
      *
      * @param  webhook
      *         The webhook
@@ -43,6 +53,8 @@ public class D4JWebhookClient extends WebhookClient {
     /**
      * Factory method to create a basic D4JWebhookClient with the provided id and token.
      *
+     * <p>You can use {@link #onThread(long)} to target specific threads on the channel.
+     *
      * @param  id
      *         The webhook id
      * @param  token
@@ -57,11 +69,13 @@ public class D4JWebhookClient extends WebhookClient {
     public static D4JWebhookClient withId(long id, @NotNull String token) {
         Objects.requireNonNull(token, "Token");
         ScheduledExecutorService pool = ThreadPools.getDefaultPool(id, null, false);
-        return new D4JWebhookClient(id, token, true, new OkHttpClient(), pool, AllowedMentions.all());
+        return new D4JWebhookClient(id, token, true, new OkHttpClient(), pool, AllowedMentions.all(), 0L);
     }
 
     /**
      * Factory method to create a basic D4JWebhookClient with the provided id and token.
+     *
+     * <p>You can use {@link #onThread(long)} to target specific threads on the channel.
      *
      * @param  url
      *         The url for the webhook
@@ -81,6 +95,12 @@ public class D4JWebhookClient extends WebhookClient {
             throw new IllegalArgumentException("Failed to parse webhook URL");
         }
         return withId(Long.parseUnsignedLong(matcher.group(1)), matcher.group(2));
+    }
+
+    @NotNull
+    @Override
+    public D4JWebhookClient onThread(final long threadId) {
+        return new D4JWebhookClient(this, threadId);
     }
 
     /**

--- a/src/main/java/club/minnced/discord/webhook/external/JDAWebhookClient.java
+++ b/src/main/java/club/minnced/discord/webhook/external/JDAWebhookClient.java
@@ -18,11 +18,21 @@ import java.util.regex.Matcher;
 
 public class JDAWebhookClient extends WebhookClient {
     public JDAWebhookClient(long id, String token, boolean parseMessage, OkHttpClient client, ScheduledExecutorService pool, AllowedMentions mentions) {
-        super(id, token, parseMessage, client, pool, mentions);
+        this(id, token, parseMessage, client, pool, mentions, 0L);
+    }
+
+    public JDAWebhookClient(long id, String token, boolean parseMessage, OkHttpClient client, ScheduledExecutorService pool, AllowedMentions mentions, long threadId) {
+        super(id, token, parseMessage, client, pool, mentions, threadId);
+    }
+
+    protected JDAWebhookClient(JDAWebhookClient parent, long threadId) {
+        super(parent, threadId);
     }
 
     /**
      * Creates a WebhookClient for the provided webhook.
+     *
+     * <p>You can use {@link #onThread(long)} to target specific threads on the channel.
      *
      * @param  webhook
      *         The webhook
@@ -39,6 +49,8 @@ public class JDAWebhookClient extends WebhookClient {
 
     /**
      * Factory method to create a basic JDAWebhookClient with the provided id and token.
+     *
+     * <p>You can use {@link #onThread(long)} to target specific threads on the channel.
      *
      * @param  id
      *         The webhook id
@@ -60,6 +72,8 @@ public class JDAWebhookClient extends WebhookClient {
     /**
      * Factory method to create a basic JDAWebhookClient with the provided id and token.
      *
+     * <p>You can use {@link #onThread(long)} to target specific threads on the channel.
+     *
      * @param  url
      *         The url for the webhook
      *
@@ -78,6 +92,12 @@ public class JDAWebhookClient extends WebhookClient {
             throw new IllegalArgumentException("Failed to parse webhook URL");
         }
         return withId(Long.parseUnsignedLong(matcher.group(1)), matcher.group(2));
+    }
+
+    @NotNull
+    @Override
+    public JDAWebhookClient onThread(long threadId) {
+        return new JDAWebhookClient(this, threadId);
     }
 
     /**

--- a/src/main/java/club/minnced/discord/webhook/external/JavacordWebhookClient.java
+++ b/src/main/java/club/minnced/discord/webhook/external/JavacordWebhookClient.java
@@ -17,11 +17,21 @@ import java.util.regex.Matcher;
 
 public class JavacordWebhookClient extends WebhookClient {
     public JavacordWebhookClient(long id, String token, boolean parseMessage, OkHttpClient client, ScheduledExecutorService pool, AllowedMentions mentions) {
-        super(id, token, parseMessage, client, pool, mentions);
+        this(id, token, parseMessage, client, pool, mentions, 0L);
+    }
+
+    public JavacordWebhookClient(long id, String token, boolean parseMessage, OkHttpClient client, ScheduledExecutorService pool, AllowedMentions mentions, long threadId) {
+        super(id, token, parseMessage, client, pool, mentions, threadId);
+    }
+
+    protected JavacordWebhookClient(JavacordWebhookClient parent, long threadId) {
+        super(parent, threadId);
     }
 
     /**
      * Creates a WebhookClient for the provided webhook.
+     *
+     * <p>You can use {@link #onThread(long)} to target specific threads on the channel.
      *
      * @param  webhook
      *         The webhook
@@ -38,6 +48,8 @@ public class JavacordWebhookClient extends WebhookClient {
 
     /**
      * Factory method to create a basic JavacordWebhookClient with the provided id and token.
+     *
+     * <p>You can use {@link #onThread(long)} to target specific threads on the channel.
      *
      * @param  id
      *         The webhook id
@@ -59,6 +71,8 @@ public class JavacordWebhookClient extends WebhookClient {
     /**
      * Factory method to create a basic JavacordWebhookClient with the provided id and token.
      *
+     * <p>You can use {@link #onThread(long)} to target specific threads on the channel.
+     *
      * @param  url
      *         The url for the webhook
      *
@@ -77,6 +91,12 @@ public class JavacordWebhookClient extends WebhookClient {
             throw new IllegalArgumentException("Failed to parse webhook URL");
         }
         return withId(Long.parseUnsignedLong(matcher.group(1)), matcher.group(2));
+    }
+
+    @NotNull
+    @Override
+    public JavacordWebhookClient onThread(long threadId) {
+        return new JavacordWebhookClient(this, threadId);
     }
 
     /**


### PR DESCRIPTION
You can target threads with either `WebhookClientBuilder#setThreadId` or `WebhookClient#onThread`. Each thread specific webhook client created by `onThread` will share all settings (including the pool). If one of these clients is shutdown/closed, all other clients will also be closed due to the shared pool.

Example:

```java
try (WebhookClient client = WebhookClient.withUrl(url)) {
  WebhookClient thread = client.onThread(123L);
  thread.send("Hello"); // appears only in the thread with id 123
  client.send("Friend"); // appears in the channel instead
}
```