### PR TITLE
Gradle action tweaks

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,21 +5,25 @@ name: Java CI with Gradle
 
 on:
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Repo
+      uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
-        distribution: 'adopt'
-        cache: gradle
+        java-version: 11
+        distribution: temurin
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build
+        gradle-version: wrapper

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,5 +25,5 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: build
+        arguments: build test
         gradle-version: wrapper


### PR DESCRIPTION
Just a couple small tweaks to the Gradle build action.

1. Switch setup-jdk distribution to `temurin` from `adopt`.\
   See setup-jdk's notice on adopt [here](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#adopt).

2. Move caching and builds to gradle-build-action.\
    Let Gradle's official build action handle caching, it caches both build-tool and dependencies.\
    Caching is enabled by default so there's no config needed for it. See [here](https://github.com/gradle/gradle-build-action#caching).

3. Run tests.\
    Pretty simple, just run tests on every PR push to prevent regression.
    