### PR TITLE
Fix UnsupportedOperationException when sending DataMessages

### DIFF
--- a/src/main/java/club/minnced/discord/webhook/send/WebhookMessageBuilder.java
+++ b/src/main/java/club/minnced/discord/webhook/send/WebhookMessageBuilder.java
@@ -433,7 +433,6 @@ public class WebhookMessageBuilder {
         WebhookMessageBuilder builder = new WebhookMessageBuilder();
         builder.setTTS(message.isTTS());
         builder.setContent(message.getContentRaw());
-        builder.setEphemeral(message.isEphemeral());
         message.getEmbeds().forEach(embed -> builder.addEmbeds(WebhookEmbedBuilder.fromJDA(embed).build()));
 
         if (message instanceof DataMessage) {
@@ -460,6 +459,7 @@ public class WebhookMessageBuilder {
                     .collect(Collectors.toList()));
             allowedMentions.withParseEveryone(message.mentionsEveryone());
             builder.setAllowedMentions(allowedMentions);
+            builder.setEphemeral(message.isEphemeral());
         }
         return builder;
     }


### PR DESCRIPTION
- Set builder#setEphemeral only when the argument is of type ReceivedMessage. All other messages (i.e. DataMessages) should use the default value instead (i.e. false).
- Add 2 test cases to check whether the UnsupportedOperationException from calling WebhookMessageBuilder#fromJDA has been resolved.