### PR TITLE
Support editing attachments in API v10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,8 +12,8 @@ plugins {
 }
 
 val major = "0"
-val minor = "8"
-val patch = "2"
+val minor = "9"
+val patch = "0"
 
 group = "club.minnced"
 version = "$major.$minor.$patch"
@@ -46,7 +46,7 @@ repositories {
 val versions = mapOf(
     "slf4j" to "1.7.32",
     "okhttp" to "4.10.0",
-    "json" to "20210307",
+    "json" to "20220320",
     "jda" to "5.0.0-alpha.13",
     "discord4j" to "3.2.2",
     "javacord" to "3.4.0",

--- a/src/main/java/club/minnced/discord/webhook/LibraryInfo.java
+++ b/src/main/java/club/minnced/discord/webhook/LibraryInfo.java
@@ -17,7 +17,7 @@
 package club.minnced.discord.webhook;
 
 public class LibraryInfo {
-    public static final int DISCORD_API_VERSION = 9;
+    public static final int DISCORD_API_VERSION = 10;
     public static final String VERSION_MAJOR = "@MAJOR@";
     public static final String VERSION_MINOR = "@MINOR@";
     public static final String VERSION_PATCH = "@PATCH@";

--- a/src/main/java/club/minnced/discord/webhook/receive/ReadonlyAttachment.java
+++ b/src/main/java/club/minnced/discord/webhook/receive/ReadonlyAttachment.java
@@ -16,6 +16,7 @@
 
 package club.minnced.discord.webhook.receive;
 
+import club.minnced.discord.webhook.send.MessageAttachment;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.json.JSONPropertyName;
@@ -26,7 +27,7 @@ import org.json.JSONString;
  * <br>This does not actually contain the file but only meta-data
  * useful to retrieve the actual attachment.
  */
-public class ReadonlyAttachment implements JSONString {
+public class ReadonlyAttachment extends MessageAttachment implements JSONString {
     private final String url;
     private final String proxyUrl;
     private final String fileName;
@@ -37,6 +38,7 @@ public class ReadonlyAttachment implements JSONString {
     public ReadonlyAttachment(
             @NotNull String url, @NotNull String proxyUrl, @NotNull String fileName,
             int width, int height, int size, long id) {
+        super(id, fileName);
         this.url = url;
         this.proxyUrl = proxyUrl;
         this.fileName = fileName;

--- a/src/main/java/club/minnced/discord/webhook/send/MessageAttachment.java
+++ b/src/main/java/club/minnced/discord/webhook/send/MessageAttachment.java
@@ -18,6 +18,8 @@ package club.minnced.discord.webhook.send;
 
 import club.minnced.discord.webhook.IOUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -28,15 +30,25 @@ import java.io.InputStream;
  * Internal representation of attachments for outgoing messages
  */
 public class MessageAttachment {
+    private static final byte[] empty = new byte[0];
+    private final long id;
     private final String name;
     private final byte[] data;
 
+    protected MessageAttachment(long id, @NotNull String name) {
+        this.id = id;
+        this.name = name;
+        this.data = empty;
+    }
+
     MessageAttachment(@NotNull String name, @NotNull byte[] data) {
+        this.id = 0;
         this.name = name;
         this.data = data;
     }
 
     MessageAttachment(@NotNull String name, @NotNull InputStream stream) throws IOException {
+        this.id = 0;
         this.name = name;
         try (InputStream data = stream) {
             this.data = IOUtil.readAllBytes(data);
@@ -47,6 +59,50 @@ public class MessageAttachment {
         this(name, new FileInputStream(file));
     }
 
+    /**
+     * Create an instance of this class with the provided ID and name.
+     *
+     * <p>This can be used in {@link club.minnced.discord.webhook.send.WebhookMessageBuilder#addFile(MessageAttachment)}
+     * to retain existing attachments on a message for an edit request.
+     * The name parameter can also be used to rename the attachment.
+     *
+     * @param  id
+     *         The snowflake ID for this attachment (must exist on the message you edit9
+     * @param  name
+     *         The new name for the attachment, or null to keep existing name
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided ID is not a valid snowflake
+     *
+     * @return The attachment instance
+     */
+    @NotNull
+    public static MessageAttachment fromId(long id, @Nullable String name) {
+        if (id > WebhookMessage.MAX_FILES)
+            throw new IllegalArgumentException("MessageAttachment ID must be higher than " + WebhookMessage.MAX_FILES + ".");
+        return new MessageAttachment(id, name == null ? "" : name);
+    }
+
+
+    /**
+     * Create an instance of this class with the provided ID and name.
+     *
+     * <p>This can be used in {@link club.minnced.discord.webhook.send.WebhookMessageBuilder#addFile(MessageAttachment)}
+     * to retain existing attachments on a message for an edit request.
+     *
+     * @param  id
+     *         The snowflake ID for this attachment (must exist on the message you edit9
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided ID is not a valid snowflake
+     *
+     * @return The attachment instance
+     */
+    @NotNull
+    public static MessageAttachment fromId(long id) {
+        return fromId(id, null);
+    }
+
     @NotNull
     public String getName() {
         return name;
@@ -55,5 +111,19 @@ public class MessageAttachment {
     @NotNull
     public byte[] getData() {
         return data;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    @NotNull
+    public JSONObject toJSON() {
+        JSONObject json = new JSONObject();
+        if (!name.isEmpty())
+            json.put("name", name);
+        if (id != 0)
+            json.put("id", id);
+        return json;
     }
 }


### PR DESCRIPTION
This is a breaking change, all file additions will now remove existing attachments. However, this change is required by Discord and I can't do anything about that.